### PR TITLE
Reject if the string is < 4 characters in order to prevent an error when parsing the structure

### DIFF
--- a/iban.cpp
+++ b/iban.cpp
@@ -157,7 +157,7 @@ bool Validate::isValid(std::string account) {
 	std::transform(account.begin(), account.end(), account.begin(), toupper);
 
 	/* Reject anything too small */
-	if (account.length() < 3) {
+	if (account.length() < 4) {
 		return false;
 	}
 


### PR DESCRIPTION
When input given is: `INSERT INTO foobar (bank_account_number) VALUES ('foo');`
Prevent this error: `ERROR:  basic_string::substr: __pos (which is 4) > this->size() (which is 3)`
Which occurs here:
```
while (std::regex_search(text_iter, structure.cend(), match, std::regex("(.{3})"))) {
		std::string format;
		char pattern = match[0].str()[0];
		int repeats = std::stoi((match[0].str().substr(1)));
```
